### PR TITLE
feat(PriceOracle): add price feed aggregator contract

### DIFF
--- a/src/contracts/PriceOracle/ChainlinkPriceFeedAggregator.sol
+++ b/src/contracts/PriceOracle/ChainlinkPriceFeedAggregator.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {AggregatorV3Interface} from
+    "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+/**
+ * @title ChainlinkPriceFeedAggregator
+ * @notice Aggregates two Chainlink price feeds to create a composite price feed
+ * @dev Implements AggregatorV3Interface to be compatible with existing price feed consumers
+ */
+contract ChainlinkPriceFeedAggregator is AggregatorV3Interface {
+    AggregatorV3Interface public immutable priceFeed1;
+    AggregatorV3Interface public immutable priceFeed2;
+    string public description;
+    uint8 public immutable decimals;
+
+    error PriceFeedsTimeMismatch(uint256 time1, uint256 time2);
+    error ZeroAddress();
+
+    // Maximum allowed time difference between price feed updates (1 hour)
+    uint256 constant MAX_TIME_DIFF = 1 hours;
+
+    constructor(
+        address priceFeed1_,
+        address priceFeed2_,
+        string memory description_,
+        uint8 decimals_
+    ) {
+        if (priceFeed1_ == address(0) || priceFeed2_ == address(0)) {
+            revert ZeroAddress();
+        }
+
+        priceFeed1 = AggregatorV3Interface(priceFeed1_);
+        priceFeed2 = AggregatorV3Interface(priceFeed2_);
+        description = description_;
+        decimals = decimals_;
+    }
+
+    /**
+     * @notice Returns the latest round data from both price feeds and calculates the composite price
+     * @dev Reverts if the price feeds are not on the same round
+     * @return roundId The round ID from the latest price update
+     * @return answer The composite price (price1 / price2)
+     * @return startedAt When the round started
+     * @return updatedAt When the round was updated
+     * @return answeredInRound The round in which the answer was computed
+     */
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        (
+            uint80 roundId1,
+            int256 price1,
+            uint256 startedAt1,
+            uint256 updatedAt1,
+            uint80 answeredInRound1
+        ) = priceFeed1.latestRoundData();
+
+        (, int256 price2,, uint256 updatedAt2,) = priceFeed2.latestRoundData();
+
+        // Ensure price updates are close in time
+        if (updatedAt1 > updatedAt2) {
+            if (updatedAt1 - updatedAt2 > MAX_TIME_DIFF) {
+                revert PriceFeedsTimeMismatch(updatedAt1, updatedAt2);
+            }
+        } else {
+            if (updatedAt2 - updatedAt1 > MAX_TIME_DIFF) {
+                revert PriceFeedsTimeMismatch(updatedAt1, updatedAt2);
+            }
+        }
+
+        // Calculate composite price: price1 / price2
+        answer = (price1 * int256(10 ** decimals)) / price2;
+
+        return (roundId1, answer, startedAt1, updatedAt1, answeredInRound1);
+    }
+
+    /**
+     * @notice Returns the round data for a specific round ID
+     * @dev Reverts if the price feeds don't have data for the requested round
+     * @param roundId_ The round ID to get price data for
+     * @return roundId The round ID
+     * @return answer The composite price
+     * @return startedAt When the round started
+     * @return updatedAt When the round was updated
+     * @return answeredInRound The round in which the answer was computed
+     */
+    function getRoundData(
+        uint80 roundId_
+    )
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        (
+            uint80 roundId1,
+            int256 price1,
+            uint256 startedAt1,
+            uint256 updatedAt1,
+            uint80 answeredInRound1
+        ) = priceFeed1.getRoundData(roundId_);
+
+        (, int256 price2,, uint256 updatedAt2,) = priceFeed2.getRoundData(roundId_);
+
+        // Ensure price updates are close in time
+        if (updatedAt1 > updatedAt2) {
+            if (updatedAt1 - updatedAt2 > MAX_TIME_DIFF) {
+                revert PriceFeedsTimeMismatch(updatedAt1, updatedAt2);
+            }
+        } else {
+            if (updatedAt2 - updatedAt1 > MAX_TIME_DIFF) {
+                revert PriceFeedsTimeMismatch(updatedAt1, updatedAt2);
+            }
+        }
+
+        // Calculate composite price: price1 / price2
+        answer = (price1 * int256(10 ** decimals)) / price2;
+
+        return (roundId1, answer, startedAt1, updatedAt1, answeredInRound1);
+    }
+
+    /**
+     * @notice Returns the version of the price feed
+     * @return The version number
+     */
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}

--- a/test/PriceOracle/ChainlinkPriceFeedAggregatorTest.t.sol
+++ b/test/PriceOracle/ChainlinkPriceFeedAggregatorTest.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {ChainlinkPriceFeedAggregator} from
+    "../../src/contracts/PriceOracle/ChainlinkPriceFeedAggregator.sol";
+import {AggregatorV3Interface} from
+    "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract MockPriceFeed is AggregatorV3Interface {
+    uint80 public roundId;
+    int256 public answer;
+    uint256 public startedAt;
+    uint256 public updatedAt;
+    uint80 public answeredInRound;
+    uint8 public decimals;
+    string public description;
+
+    constructor(uint8 decimals_, string memory description_) {
+        decimals = decimals_;
+        description = description_;
+    }
+
+    function setPriceData(
+        uint80 roundId_,
+        int256 answer_,
+        uint256 startedAt_,
+        uint256 updatedAt_,
+        uint80 answeredInRound_
+    ) external {
+        roundId = roundId_;
+        answer = answer_;
+        startedAt = startedAt_;
+        updatedAt = updatedAt_;
+        answeredInRound = answeredInRound_;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId_,
+            int256 answer_,
+            uint256 startedAt_,
+            uint256 updatedAt_,
+            uint80 answeredInRound_
+        )
+    {
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function getRoundData(
+        uint80 _roundId
+    )
+        external
+        view
+        returns (
+            uint80 roundId_,
+            int256 answer_,
+            uint256 startedAt_,
+            uint256 updatedAt_,
+            uint80 answeredInRound_
+        )
+    {
+        require(_roundId == roundId, "Round not found");
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract ChainlinkPriceFeedAggregatorTest is Test {
+    ChainlinkPriceFeedAggregator public aggregator;
+    MockPriceFeed public priceFeed1;
+    MockPriceFeed public priceFeed2;
+
+    uint8 constant DECIMALS = 8;
+    string constant DESCRIPTION = "BTC/ETH";
+
+    function setUp() public {
+        priceFeed1 = new MockPriceFeed(DECIMALS, "BTC/USD");
+        priceFeed2 = new MockPriceFeed(DECIMALS, "ETH/USD");
+
+        aggregator = new ChainlinkPriceFeedAggregator(
+            address(priceFeed1), address(priceFeed2), DESCRIPTION, DECIMALS
+        );
+    }
+
+    function testInitialState() public view {
+        assertEq(address(aggregator.priceFeed1()), address(priceFeed1));
+        assertEq(address(aggregator.priceFeed2()), address(priceFeed2));
+        assertEq(aggregator.description(), DESCRIPTION);
+        assertEq(aggregator.decimals(), DECIMALS);
+    }
+
+    function testCannotDeployWithZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(ChainlinkPriceFeedAggregator.ZeroAddress.selector));
+        new ChainlinkPriceFeedAggregator(address(0), address(priceFeed2), DESCRIPTION, DECIMALS);
+
+        vm.expectRevert(abi.encodeWithSelector(ChainlinkPriceFeedAggregator.ZeroAddress.selector));
+        new ChainlinkPriceFeedAggregator(address(priceFeed1), address(0), DESCRIPTION, DECIMALS);
+    }
+
+    function testLatestRoundData() public {
+        // Set up price data
+        uint256 timestamp = block.timestamp;
+        priceFeed1.setPriceData(1, 100_000e8, timestamp, timestamp, 1); // BTC = $100,000
+        priceFeed2.setPriceData(1, 2000e8, timestamp, timestamp, 1); // ETH = $2,000
+
+        // Get latest round data
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = aggregator.latestRoundData();
+
+        // BTC/ETH = 100,000/2,000 = 50
+        assertEq(answer, 50e8);
+        assertEq(roundId, 1);
+        assertEq(startedAt, timestamp);
+        assertEq(updatedAt, timestamp);
+        assertEq(answeredInRound, 1);
+    }
+
+    function testGetRoundData() public {
+        // Set up price data
+        uint256 timestamp = block.timestamp;
+        priceFeed1.setPriceData(1, 100_000e8, timestamp, timestamp, 1); // BTC = $100,000
+        priceFeed2.setPriceData(1, 2000e8, timestamp, timestamp, 1); // ETH = $2,000
+
+        // Get round data
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = aggregator.getRoundData(1);
+
+        // BTC/ETH = 100,000/2,000 = 50
+        assertEq(answer, 50e8);
+        assertEq(roundId, 1);
+        assertEq(startedAt, timestamp);
+        assertEq(updatedAt, timestamp);
+        assertEq(answeredInRound, 1);
+    }
+
+    function testTimeMismatch() public {
+        uint256 timestamp = block.timestamp;
+        priceFeed1.setPriceData(1, 100_000e8, timestamp, timestamp, 1);
+        priceFeed2.setPriceData(1, 2000e8, timestamp, timestamp + 2 hours, 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ChainlinkPriceFeedAggregator.PriceFeedsTimeMismatch.selector,
+                timestamp,
+                timestamp + 2 hours
+            )
+        );
+        aggregator.latestRoundData();
+    }
+
+    function testVersion() public view {
+        assertEq(aggregator.version(), 1);
+    }
+}


### PR DESCRIPTION
Add the `ChainlinkPriceFeedAggregator` contract that exposes a composite price feed by combining 2 underlying price feeds. Example of usage: price BTC in EUR by leveraging a BTC/USD and a EUR/USD price feed.